### PR TITLE
Remove invalid keys in grammar(scope, extension)

### DIFF
--- a/scripts/update-tmLanguage.ts
+++ b/scripts/update-tmLanguage.ts
@@ -30,10 +30,11 @@ import plist from "plist";
     tmLanguageExpectationFile,
     { encoding: "utf8" }
   );
-  const plistContent = plist.build(prepareJSONforPlist(JSON.parse(content)));
+  const updatedContent = prepareJSONforPlist(JSON.parse(content));
+  const plistContent = plist.build(updatedContent);
   await fs.promises.writeFile(
     expectationsFileJSON,
-    content,
+    JSON.stringify(updatedContent, null, 2),
   );
   await fs.promises.writeFile(
     expectationsFilePlist,

--- a/syntaxes/Aleo.tmLanguage.json
+++ b/syntaxes/Aleo.tmLanguage.json
@@ -1,9 +1,9 @@
 {
   "name": "Aleo",
   "scopeName": "source.aleo",
-  "scope": "source.aleo",
-  "fileTypes": ["aleo"],
-  "extension": ["aleo"],
+  "fileTypes": [
+    "aleo"
+  ],
   "patterns": [
     {
       "include": "#block_comment"


### PR DESCRIPTION
According to linguist warning
- Unknown keys in grammar: `source.aleo` (in `syntaxes/Aleo.tmLanguage.json`) contains invalid keys (`scope`, `extension`)